### PR TITLE
Stop process after deploy:updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,21 +46,21 @@ set :backburner_queues, ['default','mailer']
 set :backburner_roles, [:app]
 
 # Set the location of the backburner process id file
-# default value: 'tmp/pids/backburner.pid'
+# default value: 'File.join(shared_path, 'tmp', 'pids', 'backburner.pid')'
 set :backburner_pid, 'tmp/pids/backburner.pid'
 
-# Set the location of the backburner log file 
-# default value: 'log/backburner.log'
+# Set the location of the backburner log file
+# default value: 'File.join(shared_path, 'log', 'backburner.log')'
 set :backburner_log, 'log/backburner.log'
 
 ```
 
-It also adds the following hook
+It also adds the following hooks
 
 ```ruby
-after 'deploy:published', 'restart' do
-    invoke 'backburner:restart'
-end
+after 'deploy:reverted', 'backburner:stop'
+after 'deploy:updated', 'backburner:stop'
+after 'deploy:published', 'backburner:start'
 ```
 
 ## Contributing

--- a/lib/capistrano/tasks/backburner.rake
+++ b/lib/capistrano/tasks/backburner.rake
@@ -29,7 +29,7 @@ namespace :backburner do
   desc 'Stop the backburner process'
   task :stop do
     on roles(backburner_roles) do
-      within current_path do
+      within release_path do
         with rails_env: fetch(:rails_env) do
           execute :bundle, :exec, backburner_bin, "-k -P #{backburner_pid}"
         end
@@ -56,14 +56,15 @@ namespace :backburner do
     end
   end
 
-  after 'deploy:started', 'backburner:stop'
+  after 'deploy:reverted', 'backburner:stop'
+  after 'deploy:updated', 'backburner:stop'
   after 'deploy:published', 'backburner:start'
 end
 
 namespace :load do
   task :defaults do
-    set :backburner_pid, 'tmp/pids/backburner.pid'
-    set :backburner_log, 'log/backburner.log'
+    set :backburner_pid, File.join(shared_path, 'tmp', 'pids', 'backburner.pid')
+    set :backburner_log, File.join(shared_path, 'log', 'backburner.log')
     set :backburner_queues, nil
     set :backburner_roles, :app
   end

--- a/lib/capistrano/tasks/backburner.rake
+++ b/lib/capistrano/tasks/backburner.rake
@@ -63,8 +63,8 @@ end
 
 namespace :load do
   task :defaults do
-    set :backburner_pid, File.join(shared_path, 'tmp', 'pids', 'backburner.pid')
-    set :backburner_log, File.join(shared_path, 'log', 'backburner.log')
+    set :backburner_pid, -> { File.join(shared_path, 'tmp', 'pids', 'backburner.pid') }
+    set :backburner_log, -> { File.join(shared_path, 'log', 'backburner.log') }
     set :backburner_queues, nil
     set :backburner_roles, :app
   end


### PR DESCRIPTION
Hey,

thanks for this gem. I've got some improvements.

Stopping the Backburner process on `deploy:started` is a bit early. In fact on first deployment after `deploy:started` there won't be any `release_path` and `backburner:stop` crashes.
Also I think it's better to generate the file locations with `File.join` and `shared_path`.
A `deploy:reverted` hook was missing.

